### PR TITLE
Update className convention to something a bit more modular

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Feedback, bugs, questions? [email](mailto:contact@kumailht.com) me, I'll respond
 
 ####3. Use 'less than' and 'greater than' classes as breakpoints to write responsive CSS
 ```css
-.quote.lt500 {background: blue}
-.quote.gt150.lt300 {background: red}
+.quote.v-lt500 {background: blue}
+.quote.v-gt150.v-lt300 {background: red}
 ```
 
 ####4. Optionally declare start, end and interval values on your `data-respond` attribute to control breakpoint generation

--- a/responsive-elements.js
+++ b/responsive-elements.js
@@ -25,12 +25,12 @@ var ResponsiveElements = {
 	elementsAttributeName: 'data-respond',
 	maxRefreshRate: 5,
 	defaults: {
-		// How soon should you start adding breakpoints
-		start: 100,
-		// When to stop adding breakpoints
-		end: 900,
-		// At what interval should breakpoints be added?
-		interval: 50
+		//  Minimum width to add a breakpoint
+		min: 100,
+		// Maximum width to add a breakpoint
+		max: 900,
+		// Step amount to skip breakpoints
+		step: 50
 	},
 	init: function() {
 		var self = this;
@@ -53,7 +53,7 @@ var ResponsiveElements = {
 	},
 
 	parseOptions: function(optionsString) {
-		// data-respond="{"start": 100, "end": 900, "interval": 50, "watch": true}"
+		// data-respond="{"min": 100, "max": 900, "step": 50, "watch": true}"
 		if (!optionsString) return false;
 
 		this._optionsCache = this._optionsCache || {};
@@ -94,18 +94,18 @@ var ResponsiveElements = {
 		_el.addClass(breakpoints.join(' '));
 	},
 	generateBreakpoints: function(width, options) {
-		var start = options.start,
-			end = options.end,
-			interval = options.interval,
-			i = interval > start ? interval : ~~(start / interval) * interval,
+		var min = options.min,
+			max = options.max,
+			step = options.step,
+			i = step > min ? step : ~~(min / step) * step,
 			classes = [];
 
-		while (i <= end) {
+		while (i <= max) {
 			if (i < width) classes.push('v-gt' + i);
 			if (i > width) classes.push('v-lt' + i);
 			if (i == width) classes.push('v-lt' + i);
 
-			i += interval;
+			i += step;
 		}
 
 		return classes;

--- a/responsive-elements.js
+++ b/responsive-elements.js
@@ -37,7 +37,7 @@ var ResponsiveElements = {
 		$(function() {
 			self.el = {
 				window: $(window),
-				responsive_elements: $('[' + self.elementsAttributeName + ']')
+				responsiveElements: $('[' + self.elementsAttributeName + ']')
 			};
 
 			self.events();
@@ -45,51 +45,49 @@ var ResponsiveElements = {
 	},
 
 	addElement: function(element) {
-		this.el.responsive_elements = this.el.responsive_elements.add(element);
+		this.el.responsiveElements = this.el.responsiveElements.add(element);
 	},
 
 	removeElement: function(element) {
-		this.el.responsive_elements = this.el.responsive_elements.not(element);
+		this.el.responsiveElements = this.el.responsiveElements.not(element);
 	},
 
-	parseOptions: function(options_string) {
-		// data-respond="start: 100px; end: 900px; interval: 50px; watch: true;"
-		if (!options_string) return false;
+	parseOptions: function(optionsString) {
+		// data-respond="{"start": 100, "end": 900, "interval": 50, "watch": true}"
+		if (!optionsString) return false;
 
-		this._options_cache = this._options_cache || {};
-		if (this._options_cache[options_string]) return this._options_cache[options_string];
+		this._optionsCache = this._optionsCache || {};
+		if (this._optionsCache[optionsString]) return this._optionsCache[optionsString];
 
-		var options_array = options_string.replace(/\s+/g, '').split(';'),
-			options_object = {};
+		var optionsObject = JSON.parse(optionsString);
 
-		for (var i = 0; i < options_array.length; i++) {
-			if (!options_array[i]) continue;
-			var property_array = (options_array[i]).split(':');
+		for (var key in optionsObject) {
+			var value = optionsObject[key];
 
-			var key = property_array[0];
-			var value = property_array[1];
-
-			if (value.slice(-2) === 'px') {
+			if (value.toString().slice(-2) === 'px') {
 				value = value.replace('px', '');
 			}
+
 			if (!isNaN(value)) {
 				value = parseInt(value, 10);
 			}
-			options_object[key] = value;
+
+			optionsObject[key] = value;
 		}
 
-		this._options_cache[options_string] = options_object;
-		return options_object;
+		this._optionsCache[optionsString] = optionsObject;
+
+		return optionsObject;
 	},
 	generateBreakpointsOnAllElements: function() {
 		var self = ResponsiveElements;
-		self.el.responsive_elements.each(function(i, _el) {
+		self.el.responsiveElements.each(function(i, _el) {
 			self.generateBreakpointsOnElement($(_el));
 		});
 	},
 	generateBreakpointsOnElement: function(_el) {
-		var options_string = _el.attr(this.elementsAttributeName),
-			options = this.parseOptions(options_string) || this.defaults,
+		var optionsString = _el.attr(this.elementsAttributeName),
+			options = this.parseOptions(optionsString) || this.defaults,
 			breakpoints = this.generateBreakpoints(_el.width(), options);
 
 		this.cleanUpBreakpoints(_el);
@@ -103,21 +101,21 @@ var ResponsiveElements = {
 			classes = [];
 
 		while (i <= end) {
-			if (i < width) classes.push('gt' + i);
-			if (i > width) classes.push('lt' + i);
-			if (i == width) classes.push('lt' + i);
+			if (i < width) classes.push('v-gt' + i);
+			if (i > width) classes.push('v-lt' + i);
+			if (i == width) classes.push('v-lt' + i);
 
 			i += interval;
 		}
 
 		return classes;
 	},
-	parseBreakpointClasses: function(breakpoints_string) {
-		var classes = breakpoints_string.split(/\s+/),
+	parseBreakpointClasses: function(breakpointsString) {
+		var classes = breakpointsString.split(/\s+/),
 			breakpointClasses = [];
 
 		$(classes).each(function(i, className) {
-			if (className.match(/^gt\d+|lt\d+$/)) breakpointClasses.push(className);
+			if (className.match(/^v-gt\d+|v-lt\d+$/)) breakpointClasses.push(className);
 		});
 
 		return breakpointClasses;

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -3,45 +3,45 @@ var assert = buster.assert || assert;
 buster.testCase("Test breakpoints generation", {
 	testBreakpointGeneration: function() {
 		var breakpoints = ResponsiveElements.generateBreakpoints(420, {
-			start: 300,
-			end: 500,
-			interval: 50
+			min: 300,
+			max: 500,
+			step: 50
 		});
 		var expected = ["v-gt300", "v-gt350", "v-gt400", "v-lt450", "v-lt500"];
 		assert.equals(breakpoints, expected);
 	},
 	outOfBoundBreakpoint: function() {
 		var breakpoints = ResponsiveElements.generateBreakpoints(920, {
-			start: 300,
-			end: 500,
-			interval: 50
+			min: 300,
+			max: 500,
+			step: 50
 		});
 		var expected = ["v-gt300", "v-gt350", "v-gt400", "v-gt450", "v-gt500"];
 		assert.equals(breakpoints, expected);
 	},
 	outOfBoundBreakpoint2: function() {
 		var breakpoints = ResponsiveElements.generateBreakpoints(120, {
-			start: 300,
-			end: 500,
-			interval: 50
+			min: 300,
+			max: 500,
+			step: 50
 		});
 		var expected = ["v-lt300", "v-lt350", "v-lt400", "v-lt450", "v-lt500"];
 		assert.equals(breakpoints, expected);
 	},
 	invalidInterval: function() {
 		var breakpoints = ResponsiveElements.generateBreakpoints(120, {
-			start: 300,
-			end: 500,
-			interval: 1000
+			min: 300,
+			max: 500,
+			step: 1000
 		});
 		var expected = [];
 		assert.equals(breakpoints, expected);
 	},
 	invalidStart: function() {
 		var breakpoints = ResponsiveElements.generateBreakpoints(200, {
-			start: 1000,
-			end: 500,
-			interval: 50
+			min: 1000,
+			max: 500,
+			step: 50
 		});
 		var expected = [];
 		assert.equals(breakpoints, expected);
@@ -61,28 +61,28 @@ buster.testCase("Test breakpoint classes parsing", {
 
 buster.testCase("Test option parsing", {
 	testOptionsParsing: function() {
-		var options = ResponsiveElements.parseOptions('{"start": 100, "end": 900, "interval": 50}');
+		var options = ResponsiveElements.parseOptions('{"min": 100, "max": 900, "step": 50}');
 		var expected = {
-			start: 100,
-			end: 900,
-			interval: 50
+			min: 100,
+			max: 900,
+			step: 50
 		};
 
 		assert.equals(options, expected);
 	},
 	testOptionsParsingWithStringValues: function() {
-		var options = ResponsiveElements.parseOptions('{"start": "100px", "end": "900px", "interval": "50px"}');
+		var options = ResponsiveElements.parseOptions('{"min": "100px", "max": "900px", "step": "50px"}');
 		var expected = {
-			start: 100,
-			end: 900,
-			interval: 50
+			min: 100,
+			max: 900,
+			step: 50
 		};
 
 		assert.equals(options, expected);
 	},
 	testOptionsParsingWithInvalidJSON: function() {
 		assert.exception(function() {
-			ResponsiveElements.parseOptions('{start');
+			ResponsiveElements.parseOptions('{min');
 		}, {name: 'SyntaxError'});
 	}
 });

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -1,3 +1,5 @@
+var assert = buster.assert || assert;
+
 buster.testCase("Test breakpoints generation", {
 	testBreakpointGeneration: function() {
 		var breakpoints = ResponsiveElements.generateBreakpoints(420, {
@@ -5,7 +7,7 @@ buster.testCase("Test breakpoints generation", {
 			end: 500,
 			interval: 50
 		});
-		var expected = ["gt300", "gt350", "gt400", "lt450", "lt500"];
+		var expected = ["v-gt300", "v-gt350", "v-gt400", "v-lt450", "v-lt500"];
 		assert.equals(breakpoints, expected);
 	},
 	outOfBoundBreakpoint: function() {
@@ -14,7 +16,7 @@ buster.testCase("Test breakpoints generation", {
 			end: 500,
 			interval: 50
 		});
-		var expected = ["gt300", "gt350", "gt400", "gt450", "gt500"];
+		var expected = ["v-gt300", "v-gt350", "v-gt400", "v-gt450", "v-gt500"];
 		assert.equals(breakpoints, expected);
 	},
 	outOfBoundBreakpoint2: function() {
@@ -23,7 +25,7 @@ buster.testCase("Test breakpoints generation", {
 			end: 500,
 			interval: 50
 		});
-		var expected = ["lt300", "lt350", "lt400", "lt450", "lt500"];
+		var expected = ["v-lt300", "v-lt350", "v-lt400", "v-lt450", "v-lt500"];
 		assert.equals(breakpoints, expected);
 	},
 	invalidInterval: function() {
@@ -49,8 +51,8 @@ buster.testCase("Test breakpoints generation", {
 buster.testCase("Test breakpoint classes parsing", {
 	testBreakpointClassesParsing: function() {
 		var parsed_classes = ResponsiveElements.parseBreakpointClasses(
-			'lt238 gt390 ewjfewqh weuhltwioa qwuigtwio gtweih lthiew 3829');
-		var expected = ['lt238', 'gt390'];
+			'v-lt238 v-gt390 ewjfewqh weuhltwioa qwuigtwio gtweih lthiew 3829');
+		var expected = ['v-lt238', 'v-gt390'];
 
 		assert.equals(parsed_classes, expected);
 	}
@@ -59,7 +61,7 @@ buster.testCase("Test breakpoint classes parsing", {
 
 buster.testCase("Test option parsing", {
 	testOptionsParsing: function() {
-		var options = ResponsiveElements.parseOptions('start: 100px; end: 900px; interval: 50px;');
+		var options = ResponsiveElements.parseOptions('{"start": 100, "end": 900, "interval": 50}');
 		var expected = {
 			start: 100,
 			end: 900,
@@ -68,8 +70,8 @@ buster.testCase("Test option parsing", {
 
 		assert.equals(options, expected);
 	},
-	testOptionsParsingWithSpaces: function() {
-		var options = ResponsiveElements.parseOptions('st art:    100 px; end   :    900px; interval: 50px;');
+	testOptionsParsingWithStringValues: function() {
+		var options = ResponsiveElements.parseOptions('{"start": "100px", "end": "900px", "interval": "50px"}');
 		var expected = {
 			start: 100,
 			end: 900,
@@ -78,13 +80,9 @@ buster.testCase("Test option parsing", {
 
 		assert.equals(options, expected);
 	},
-	testOptionsParsingWithoutPixels: function() {
-		var options = ResponsiveElements.parseOptions('start: 100; end: 900; interval: 50');
-		var expected = {
-			start: 100,
-			end: 900,
-			interval: 50
-		};
-		assert.equals(typeof options.start, typeof expected.start);
+	testOptionsParsingWithInvalidJSON: function() {
+		assert.exception(function() {
+			ResponsiveElements.parseOptions('{start');
+		}, {name: 'SyntaxError'});
 	}
 });

--- a/website/index.html
+++ b/website/index.html
@@ -28,21 +28,21 @@ Don't judge a book by its cover. Or something like that.
 		.quote .author-photo,
 		.quote .author-thumb
 		{display:none;}
-		.quote.gt250 .author-context {font-family:sans-serif; color:#aaa}
+		.quote.v-gt250 .author-context {font-family:sans-serif; color:#aaa}
 
-		.quote.lt150 .words {font-size:14px; word-spacing:-1px; line-height:1.2}
-		.quote.lt150 .author {font-size:11px; margin-top:5px}
+		.quote.v-lt150 .words {font-size:14px; word-spacing:-1px; line-height:1.2}
+		.quote.v-lt150 .author {font-size:11px; margin-top:5px}
 
-		.quote.gt250 .words {font-size:22px}
-		.quote.gt250 .author {margin-top:20px}
-		.quote.gt250 .author-context {display:block; font-size:10px;}
-		.quote.gt250 .author-thumb {display:block; width:40px; float:left; margin:20px 10px 0 0;}
+		.quote.v-gt250 .words {font-size:22px}
+		.quote.v-gt250 .author {margin-top:20px}
+		.quote.v-gt250 .author-context {display:block; font-size:10px;}
+		.quote.v-gt250 .author-thumb {display:block; width:40px; float:left; margin:20px 10px 0 0;}
 
-		.quote.gt450 .words {font-size:26px;}
-		.quote.gt450 .author {font-size:16px}
-		.quote.gt450 .author-context {display:block; font-size:12px;}
-		.quote.gt450 .author-thumb {display:none;}
-		.quote.gt450 .author-photo {display:block; width:170px; float:right; margin-left:20px}
+		.quote.v-gt450 .words {font-size:26px;}
+		.quote.v-gt450 .author {font-size:16px}
+		.quote.v-gt450 .author-context {display:block; font-size:12px;}
+		.quote.v-gt450 .author-thumb {display:none;}
+		.quote.v-gt450 .author-photo {display:block; width:170px; float:right; margin-left:20px}
 	</style>
 
 	<script type="text/javascript">
@@ -112,20 +112,20 @@ Don't judge a book by its cover. Or something like that.
 	<br>
 	<h2>How it works</h2>
 	<p>The above demo element has the following classes attached to it. <b>Go ahead and drag the slider to see these classes update.</b></p>
-	<b><code class="live-classes" style="color: #217867; margin-bottom:0">gt50 gt100 gt150 gt200 gt250 gt300 gt350 gt400 gt450 gt500 gt550 gt600 gt650 lt700 lt750 lt800 lt850 lt900 lt950</code></b>
+	<b><code class="live-classes" style="color: #217867; margin-bottom:0">v-gt50 v-gt100 v-gt150 v-gt200 v-gt250 v-gt300 v-gt350 v-gt400 v-gt450 v-gt500 v-gt550 v-gt600 v-gt650 v-lt700 v-lt750 v-lt800 v-lt850 v-lt900 v-lt950</code></b>
 
 	<p><b><mark>These classes hold information. They tell you how big your element is.</mark></b> Classes are prepended with either 'lt' or 'gt' which stand for 'less than' and 'greater than'.  These classes always reflect the real width of the element.  That is what makes responsive elements possible.</p>
 
 
 	<!-- <h2>Examples</h2> --> <br>
-	<p><b>A class of 'gt300' means the element has a width 'greater than' 300 pixels. Here is some example CSS to color our element red when the width exceeds 300 pixels:</b></p>
-	<code>.quote<b>.gt300</b> {background: red}</code>
+	<p><b>A class of 'v-gt300' means the element has a width 'greater than' 300 pixels. Here is some example CSS to color our element red when the width exceeds 300 pixels:</b></p>
+	<code>.quote<b>.v-gt300</b> {background: red}</code>
 
 	<p><b>Or color it blue when its width is 'less than' 500 pixels:</b></p>
-	<code>.quote<b>.lt500</b> {background: blue}</code>
+	<code>.quote<b>.v-lt500</b> {background: blue}</code>
 
 	<p><b>Or combine them both by chaining another class. Here's the CSS to color the background yellow when the element is greater than 250 but less than 600 pixels:</b></p>
-	<code>.quote<b>.gt250.lt600</b> {background: blue}</code>
+	<code>.quote<b>.v-gt250.v-lt600</b> {background: blue}</code>
 
 	<br>
 	<h2>Usage</h2>
@@ -137,8 +137,8 @@ Don't judge a book by its cover. Or something like that.
 	<code>&lt;div class=&quot;quote&quot; <mark><b>data-respond</b></mark>&gt;</code>
 
 	<p><span>3.</span>Use 'less than' and 'greater than' classes as breakpoints to write responsive CSS.</p>
-	<code><pre>.quote<b>.lt500</b> {background: blue}
-.quote<b>.gt150.lt300</b> {background: red}
+	<code><pre>.quote<b>.v-lt500</b> {background: blue}
+.quote<b>.v-gt150.v-lt300</b> {background: red}
 </pre></code>
 
 	<center>


### PR DESCRIPTION
This has breaking changes, but I feel like this API is more fitting.

* Update the class name convention to something like the widely used `.u-` class prefixes for utilities. So I used `.v-` for component view size.
* Update all of the variable names to something more like JavaScript
* Update option names to be the same as those of an HTML range (consistency with the web)